### PR TITLE
plugin.xml for cordova 8.00 & android 7.00

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
             <uses-permission android:name="android.permission.READ_PHONE_STATE" />
         </config-file>
 
-        <source-file src="src/android/com.datecs.api.jar" target-dir="libs" framework="true" />
+        <lib-file src="src/android/com.datecs.api.jar" arch="device" />
         <source-file src="src/android/DatecsPrinter.java" target-dir="src/com/giorgiofellipe/datecsprinter" />
         <source-file src="src/android/DatecsSDKWrapper.java" target-dir="src/com/giorgiofellipe/datecsprinter" />
         <source-file src="src/android/DatecsUtil.java" target-dir="src/com/giorgiofellipe/datecsprinter" />


### PR DESCRIPTION
Using source-file on cordova 8 gives build error : 

> Parsing E:\Apps\guiasdosom\v5\platforms\android\res\xml\config.xml failed
(node:9000) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, open 'E:\Apps\guiasdosom\v5\platforms\android\res\xml\config.xml'
(node:9000) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

Using the tag lib-file fixes it.